### PR TITLE
Pull request to fix Issue #1

### DIFF
--- a/tasks/version-check-grunt.js
+++ b/tasks/version-check-grunt.js
@@ -59,7 +59,7 @@ function bowerCallback(dependency) {
 
                 callback(null, _.merge({
                     latest : latest,
-                    upToDate : semver.satisfies(latest, version)
+                    upToDate : semver.satisfies(latest, dependency.version)
                 }, dependency));
             });
     };
@@ -74,7 +74,7 @@ function npmCallback(dependency) {
 
             callback(null, _.merge({
                 latest : latest,
-                upToDate : semver.satisfies(latest, version)
+                upToDate : semver.satisfies(latest, dependency.version)
             }, dependency));
         });
     };


### PR DESCRIPTION
Using `semver.validRange` to determine if a version string is valid. If it is not, don't include that module in the report.
