### PR TITLE
Fix fatal Error when npm.commands.info returns empty object

### DIFF
--- a/tasks/version-check-grunt.js
+++ b/tasks/version-check-grunt.js
@@ -69,6 +69,9 @@ function npmCallback(dependency) {
   return function(callback) {
     npm.commands.info([dependency.name, 'version'], true, function(err, data) {
       // Data is structured as: { '1.2.1': { version: '1.2.1' } } so get the first key of the object
+      if (!data || !Object.keys(data).length) {
+        return callback(null, null);
+      }
       var latest = data[Object.keys(data)[0]].version;
 
       callback(null, _.merge({

--- a/tasks/version-check-grunt.js
+++ b/tasks/version-check-grunt.js
@@ -68,10 +68,13 @@ function bowerCallback(dependency) {
 function npmCallback(dependency) {
   return function(callback) {
     npm.commands.info([dependency.name, 'version'], true, function(err, data) {
-      // Data is structured as: { '1.2.1': { version: '1.2.1' } } so get the first key of the object
       if (!data || !Object.keys(data).length) {
-        return callback(null, null);
+        return callback(null, _.merge({
+          latest : "unknown",
+          upToDate : true
+        }, dependency));
       }
+      // Data is structured as: { '1.2.1': { version: '1.2.1' } } so get the first key of the object
       var latest = data[Object.keys(data)[0]].version;
 
       callback(null, _.merge({


### PR DESCRIPTION
This pull request fixes the following error:
```
Fatal error: Cannot read property 'version' of undefined
TypeError: Cannot read property 'version' of undefined
    at C:\Users\Felicien\git\TweakStyle\node_modules\grunt-version-check\tasks\version-check-grunt.js:72:46
    at C:\Users\Felicien\git\TweakStyle\node_modules\npm\lib\view.js:144:28
    at saved (C:\Users\Felicien\git\TweakStyle\node_modules\npm\lib\cache\caching-client.js:173:7)
    at C:\Users\Felicien\git\TweakStyle\node_modules\bower\node_modules\bower-json\node_modules\graceful-fs\polyfills.js:133:7
    at C:\Users\Felicien\git\TweakStyle\node_modules\npm\node_modules\graceful-fs\polyfills.js:210:7
    at FSReqWrap.oncomplete (fs.js:82:15)
```

It happened when npm.commands.info returns null or empty data.
I got this error with `npm 3.3.6` and `electron-prebuilt` dependency.
It may be due to the last published version number (0.34.4) is lower than my current version (0.35.1).

With this fix, the resolved last version is `unknown` and the package is supposed to be up-to-date :
```
Running "versioncheck" task
>> electron-prebuilt (npm) is up to date.
```
