### PR TITLE
fail grunt if outdated versions found

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
     "bower": "^1.5.2",
     "colors": "^1.1.2",
     "grunt": ">=0.4.5",
-    "grunt-contrib-jshint": "^0.11.3",
     "lodash": "^3.10.1",
     "npm": "^2.14.2",
     "semver": "^5.0.1"
+  },
+  "devDependencies": {
+    "grunt-contrib-jshint": "^0.11.3"
   },
   "keywords": [
     "gruntplugin",

--- a/tasks/version-check-grunt.js
+++ b/tasks/version-check-grunt.js
@@ -16,7 +16,7 @@ require('colors');
 
 /*
   Takes either a bower.json or package.json and returns some metadata about each object
-   
+
   Input: (bower.json)
   { name: "my-bower-component", dependencies: {"foo" : "1.2.3"}, devDependencies: {"bar" : "4.5.6"} }
 
@@ -121,7 +121,7 @@ module.exports = function(grunt) {
     if (this.data.bowerLocation) {
       options.bowerLocation = this.data.bowerLocation;
     }
-    
+
     if (this.data.showPrerelease) {
       options.showPrerelease = this.data.showPrerelease;
     }
@@ -137,7 +137,7 @@ module.exports = function(grunt) {
     _.each(allDependencies, function(dependency) {
       var version = dependency.version;
 
-      // Make sure the version string is readable by semver 
+      // Make sure the version string is readable by semver
       if (semver.validRange(version)) {
         switch (dependency.type) {
           case 'bower':
@@ -152,8 +152,12 @@ module.exports = function(grunt) {
 
     npm.load({}, function() {
       async.parallel(dependencyCalls, function(err, results) {
+		    var allValid = true;
+
         _.each(_.sortBy(results, sortFunc), function(result) {
           if (!result.upToDate) {
+            allValid = false;
+
             grunt.log.warn(result.name +
               (' (' + result.type + ')' + ' is out of date. Your version: ' + result.version + ' latest: ' + result.latest).yellow);
           } else {
@@ -162,8 +166,8 @@ module.exports = function(grunt) {
             }
           }
         });
-        
-        done();
+
+        done(allValid);
       });
     });
 

--- a/tasks/version-check-grunt.js
+++ b/tasks/version-check-grunt.js
@@ -152,7 +152,7 @@ module.exports = function(grunt) {
 
     npm.load({}, function() {
       async.parallel(dependencyCalls, function(err, results) {
-		    var allValid = true;
+        var allValid = true;
 
         _.each(_.sortBy(results, sortFunc), function(result) {
           if (!result.upToDate) {


### PR DESCRIPTION
In case of outdated version found, grunt should fail. 
In addition I moved jshint to dev dependencies.
I would have liked to also move grunt to peer dependencies but decided to leave it out of this PR.